### PR TITLE
docs:  fix the next step in nonblocking-schema-changes page

### DIFF
--- a/content/docs/concepts/nonblocking-schema-changes.mdx
+++ b/content/docs/concepts/nonblocking-schema-changes.mdx
@@ -118,8 +118,8 @@ Get help from [PlanetScale's support team](https://www.planetscale.com/support),
 <NextBlock
   steps={[
     {
-      text: 'Branching',
-      link: '/concepts/branching',
+      text: 'Security',
+      link: '/concepts/security',
     }
   ]}
 ></NextBlock>


### PR DESCRIPTION
Fix branching's next page jump to nonblocking-schema-changes and nonblocking-schema-changes jump back to branching , the security page is ignored .