### PR TITLE
docs: fix nextpage reference

### DIFF
--- a/content/docs/concepts/nonblocking-schema-changes.mdx
+++ b/content/docs/concepts/nonblocking-schema-changes.mdx
@@ -118,8 +118,8 @@ Get help from [PlanetScale's support team](https://www.planetscale.com/support),
 <NextBlock
   steps={[
     {
-      text: 'Branching',
-      link: '/concepts/branching',
+      text: 'Security',
+      link: '/concepts/secuity',
     }
   ]}
 ></NextBlock>


### PR DESCRIPTION
With this PR, the pointer to next page on Nonblocking schema change
has been updated to point security page